### PR TITLE
Fix shaders for OpenGL 3.2 compliance

### DIFF
--- a/pysrc/pcbre/resources/shaders/frag1.glsl
+++ b/pysrc/pcbre/resources/shaders/frag1.glsl
@@ -1,7 +1,9 @@
-#version 330
+#version 150
 
 in vec4 color_vtx;
+out vec4 FragColor;
+
 void main(void)
 {
-    gl_FragColor = color_vtx;
+    FragColor = color_vtx;
 }

--- a/pysrc/pcbre/resources/shaders/image_frag.glsl
+++ b/pysrc/pcbre/resources/shaders/image_frag.glsl
@@ -1,11 +1,13 @@
-#version 330
+#version 150
 
 in vec2 pos;
+out vec4 FragColor;
 
 uniform sampler2D tex1;
 
 void main(void)
 {
-    vec4 tex = texture2D(tex1, pos);
-    gl_FragColor = vec4(tex.r, tex.g, tex.b, 1);
+    vec4 tex = texture(tex1, pos);
+    FragColor = vec4(tex.r, tex.g, tex.b, 1);
 }
+

--- a/pysrc/pcbre/resources/shaders/image_vert.glsl
+++ b/pysrc/pcbre/resources/shaders/image_vert.glsl
@@ -1,6 +1,6 @@
-#version 330
-
+#version 150
 uniform mat3 mat;
+
 in vec2 vertex;
 in vec2 texpos;
 

--- a/pysrc/pcbre/resources/shaders/line_vertex_shader.glsl
+++ b/pysrc/pcbre/resources/shaders/line_vertex_shader.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 uniform mat3 mat;
 

--- a/pysrc/pcbre/resources/shaders/tex_frag.glsl
+++ b/pysrc/pcbre/resources/shaders/tex_frag.glsl
@@ -1,21 +1,21 @@
-#version 330
+#version 150
 
 in vec2 pos;
 
 uniform sampler2D tex1;
 uniform vec4 color;
+out vec4 FragColor;
 //uniform float gamma;
 
 
 void main(void)
 {
-    float dist = texture2D(tex1, pos).r;
+    float dist = texture(tex1, pos).r;
     float d = dist - 0.75;
 
-    float aa = clamp(0.75*length( vec2( dFdx( d ), dFdy( d ))), 0.001, 1);
-
-
+    float aa = clamp(0.75*length( vec2( dFdx( d ), dFdy( d ))), 0.001, 1.0);
     vec4 newcolor = color;
     newcolor.a *= smoothstep(-aa, +aa, dist - 0.75);
-    gl_FragColor = newcolor;
+    FragColor = newcolor;
 }
+

--- a/pysrc/pcbre/resources/shaders/vert1.glsl
+++ b/pysrc/pcbre/resources/shaders/vert1.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 uniform mat3 mat;
 in vec2 vertex;

--- a/pysrc/pcbre/resources/shaders/vert2.glsl
+++ b/pysrc/pcbre/resources/shaders/vert2.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 uniform mat3 mat;
 uniform vec4 color;

--- a/pysrc/pcbre/resources/shaders/via_filled_fragment_shader.glsl
+++ b/pysrc/pcbre/resources/shaders/via_filled_fragment_shader.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 in float ax;
 in float ay;
@@ -6,14 +6,16 @@ in float ay;
 in float _r_inside_frac_sq;
 in vec4 _color;
 
+out vec4 FragColor;
+
 void main() {
 
     float d2 = ax * ax + ay * ay;
 
     if  (d2 > 1 || d2 < _r_inside_frac_sq)
-        gl_FragColor = vec4(0,0,0,0);
+        FragColor = vec4(0,0,0,0);
     else
-        gl_FragColor = _color;
+        FragColor = _color;
 
 
 }

--- a/pysrc/pcbre/resources/shaders/via_filled_vertex_shader.glsl
+++ b/pysrc/pcbre/resources/shaders/via_filled_vertex_shader.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 
 uniform mat3 mat;

--- a/pysrc/pcbre/resources/shaders/via_outline_vertex_shader.glsl
+++ b/pysrc/pcbre/resources/shaders/via_outline_vertex_shader.glsl
@@ -1,4 +1,4 @@
-#version 330
+#version 150
 
 
 uniform mat3 mat;


### PR DESCRIPTION
This fixes all shaders for OpenGL 3.2 compliance. The code appears to work correctly.