### PR TITLE
Include ttf files in package resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(  name="pcbre",
         package_dir = {'': 'pysrc'},
 
         package_data = {
-            '': ['*.svg', '*.glsl', '*.capnp']
+            '': ['*.svg', '*.glsl', '*.capnp', '*.ttf']
         },
 
         entry_points = { 'console_scripts': [


### PR DESCRIPTION
This allows pcbre to function if one uses python setup.py install rather than develop, as the ttf font needs to be installed too.