### PR TITLE
Don't crash if no images are defined

### DIFF
--- a/pysrc/pcbre/ui/boardviewwidget.py
+++ b/pysrc/pcbre/ui/boardviewwidget.py
@@ -488,7 +488,7 @@ class BoardViewWidget(BaseViewWidget):
 
         # Render all images down onto the layer
         with Timer() as il_timer:
-            if self.viewState.show_images:
+            if self.viewState.show_images and (len(stackup_layer.imagelayers) > 0):
                 images = list(stackup_layer.imagelayers)
                 i = self.viewState.layer_permute % len(images)
                 images_cycled = images[i:] + images[:i]


### PR DESCRIPTION
This allows use without any images defined (not that anyone would want to do this, but it does make testing easier).