### PR TITLE
Allow viewport panning with space bar + drag

### DIFF
--- a/pysrc/pcbre/ui/boardviewwidget.py
+++ b/pysrc/pcbre/ui/boardviewwidget.py
@@ -161,8 +161,8 @@ class BaseViewWidget(QtOpenGL.QGLWidget):
         self.viewState.changed.connect(self.update)
 
         # Nav Handling
-        self.move_key_pressed = False
-        self.move_dragging = False
+        self.__move_key_pressed = False
+        self.__move_dragging = False
         self.move_dragged = False
         self.mwemu = False
         self.lastPoint = None
@@ -177,7 +177,33 @@ class BaseViewWidget(QtOpenGL.QGLWidget):
         # OpenGL shared resources object. Initialized during initializeGL
         self.gls = GLShared()
 
+    def _set_drag_cursor(self, dragging):
+        qapp = QtGui.QApplication.instance()
+        if not qapp:
+            return
 
+        if dragging and not qapp.overrideCursor():
+            qapp.setOverrideCursor(QtCore.Qt.OpenHandCursor)
+        elif not dragging and qapp.overrideCursor():
+            qapp.restoreOverrideCursor()
+
+    @property
+    def move_dragging(self):
+        return self.__move_dragging
+
+    @move_dragging.setter
+    def move_dragging(self, v):
+        self.__move_dragging = v
+        self._set_drag_cursor(v)
+
+    @property
+    def move_key_pressed(self):
+        return self.__move_key_pressed
+
+    @move_key_pressed.setter
+    def move_key_pressed(self, v):
+        self.__move_key_pressed = v
+        self._set_drag_cursor(v)
 
     def eventFilter(self, target, event):
         if self.interactionDelegate is None:
@@ -575,6 +601,3 @@ class BoardViewWidget(BaseViewWidget):
 
         all_time = time.time() - t_render_start
         print("Render time all: %f ot: %f cmp: %f aw: %f gl: %f" % (all_time, other_timer.interval, cmp_timer.interval, t_aw.interval, t.interval))
-
-
-


### PR DESCRIPTION
This patch allows you to pan the viewport by holding the spacebar and dragging with the left mouse button.

The behavior mimics Photoshop and frees the right mouse button for context menus and component rotation (as in EAGLE).